### PR TITLE
Fix kicks from inexistent levels on load or tp

### DIFF
--- a/MultiWorld/resources/languages/en_US.yml
+++ b/MultiWorld/resources/languages/en_US.yml
@@ -26,7 +26,7 @@ create-done: 'worlds {%0} was generated using seed: {%1} and generator: {%2}.'
 
 # Teleport Command:
 teleport-usage: '§cUsage: §7/mw teleport <world> [player]'
-teleport-notexists: '§cWorld {%0} has not been created yet. Try /mw create to create a world.'
+teleport-levelnotexists: '§cWorld {%0} has not been created yet. Try /mw create to create a world.'
 teleport-load: 'Loading world {%0}...'
 teleport-done-1: '§aYou were teleported to {%0}.'
 teleport-done-2: '§aPlayer {%1} was teleported to {%0}.'
@@ -37,7 +37,7 @@ list-done: '§aWorlds ({%0}):'
 
 # Load Command:
 load-usage: '§cUsage: §7/mw load <world>'
-load-levelnotexists: '§cWorld {%0} does not exist.'
+load-notexists: '§cWorld {%0} does not exist.'
 load-loaded: '§cUnable to load the world.'
 load-done: '§aWorld loaded.'
 


### PR DESCRIPTION
I mixed tp and load around, load had levelnotexists, and teleport had plain "notexists", so yeah. Fixed here.