### PR TITLE
support php 8.0.3

### DIFF
--- a/MultiWorld/src/czechpmdevs/multiworld/util/LanguageManager.php
+++ b/MultiWorld/src/czechpmdevs/multiworld/util/LanguageManager.php
@@ -96,7 +96,7 @@ class LanguageManager {
             $message = self::$languages[$lang][$msg];
 
             foreach ($params as $index => $param) {
-                $message = str_replace("{%$index}", $param, $message);
+                $message = str_replace("{%$index}",(string) $param, $message);
             }
 
 


### PR DESCRIPTION
> I use deepl translation and google translate.
## pull request overview
With this PR, multiworld will be supported under the php8.0 environment.
It is possible that unknown bugs are lurking.
## environment
```
multiworld: 1.5.2 (poggit release)
PocketMine-MP: 3.18.0
php: 8.0.3
os: windows
```
## tested with the following php versions.
```
PHP 8.0.3
PHP 7.4.10
```
## How to duplicate this issue
```
1. Install php8.0.3(RC1), PocketMine-MP(3.18.0), multiworld(1.5.2, from poggit) and start the server.
2. Execute the following command.
/mw create world2 0 Normal
```
## Backtrace
```
> mw create world2 0 Normal
[INFO]: Preparing world "world2"
[NOTICE]: Spawn terrain for world "world2" is being generated in the background
[CRITICAL]: TypeError: "str_replace(): Argument #2 ($replace) must be of type array|string, int given" (EXCEPTION) in "plugins/MultiWorld (3).phar/src/czechpmdevs/multiworld/util/LanguageManager" at line 99
[CRITICAL]: #0 plugins/MultiWorld (3).phar/src/czechpmdevs/multiworld/util/LanguageManager(99): str_replace(string[4] {%1}, integer 0, string[65] worlds world2 was generated using seed: {%1} and generator: {%2}.)
[CRITICAL]: #1 plugins/MultiWorld (3).phar/src/czechpmdevs/multiworld/command/subcommand/CreateSubcommand(112): czechpmdevs\multiworld\util\LanguageManager::getMsg(object pocketmine\command\ConsoleCommandSender, string[11] create-done, array[3])
[CRITICAL]: #2 plugins/MultiWorld (3).phar/src/czechpmdevs/multiworld/command/MultiWorldCommand(117): czechpmdevs\multiworld\command\subcommand\CreateSubcommand->executeSub(object pocketmine\command\ConsoleCommandSender, array[3], string[6] create)
[CRITICAL]: #3 pmsrc/src/pocketmine/command/SimpleCommandMap(248): czechpmdevs\multiworld\command\MultiWorldCommand->execute(object pocketmine\command\ConsoleCommandSender, string[2] mw, array[3])
[CRITICAL]: #4 pmsrc/src/pocketmine/Server(1809): pocketmine\command\SimpleCommandMap->dispatch(object pocketmine\command\ConsoleCommandSender, string[25] mw create world2 0 Normal)
[CRITICAL]: #5 pmsrc/src/pocketmine/Server(1422): pocketmine\Server->dispatchCommand(object pocketmine\command\ConsoleCommandSender, string[25] mw create world2 0 Normal)
[CRITICAL]: #6 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(113): pocketmine\Server->pocketmine\{closure}()
```
https://crash.pmmp.io/view/4835156
