### PR TITLE
Load the plugin on post world

### DIFF
--- a/MultiWorld/plugin.yml
+++ b/MultiWorld/plugin.yml
@@ -6,6 +6,7 @@ version: 1.6.0-beta1
 main: czechpmdevs\multiworld\MultiWorld
 description: Plugin that manage with worlds
 website: https://github.com/CzechPMDevs/MultiWorld
+load: POSTWORLD
 
 permissions:
   mw.cmd:


### PR DESCRIPTION
Or else if the default level is generated with generators in MultiWorld, **it will get loaded by the server even before the MultiWorld plugins is enabeld and register its generators.**

This cause a critical error of default level cannot be load, the only way is to set the default level to a dummy level and teleport player to the real default level on join!