### PR TITLE
Fixes GameruleRead crash

### DIFF
--- a/src/czechpmdevs/multiworld/level/gamerules/GameRules.php
+++ b/src/czechpmdevs/multiworld/level/gamerules/GameRules.php
@@ -145,10 +145,28 @@ final class GameRules {
     public function getBool(string $index): bool {
         $value = $this->gameRules[$index] ?? null;
         if(!is_bool($value)) {
-            throw new InvalidStateException("Received invalid type for Game Rule $index, expected bool.");
+            if(is_int($value)) {
+              switch ($value) {
+                  case 0;
+                  return false;
+                  break;
+                  
+                  case 1;
+                  return true;
+                  break;
+              }
+                  
+            }
+           // throw new InvalidStateException("Received invalid type for Game Rule $index, expected bool.");
+        }
+        if ($value=="true") {
+            return true;
+        }
+        if ($value=="false") {
+            return false;
         }
 
-        return $value;
+        return true;;
     }
 
     /**
@@ -247,7 +265,7 @@ final class GameRules {
      * Unserializes GameRules from World Provider
      */
     public static function unserializeGameRules(CompoundTag $nbt): GameRules {
-        return new GameRules(array_map(function (StringTag $stringTag) {
+        return new GameRules(array_map(function ($stringTag) {
             if($stringTag->getValue() == "true") {
                 return true;
             }

--- a/src/czechpmdevs/multiworld/level/gamerules/GameRules.php
+++ b/src/czechpmdevs/multiworld/level/gamerules/GameRules.php
@@ -145,7 +145,7 @@ final class GameRules {
     public function getBool(string $index): bool {
         $value = $this->gameRules[$index] ?? null;
         if(!is_bool($value)) {
-            if(is_int($value)) {
+            if(is_int($value)) { //Int to Bool
               switch ($value) {
                   case 0;
                   return false;
@@ -155,10 +155,11 @@ final class GameRules {
                   return true;
                   break;
               }
-                  
+           
             }
-           // throw new InvalidStateException("Received invalid type for Game Rule $index, expected bool.");
+
         }
+        //The original Code, (Only expects stringTag some Plugins change the typeTag such as VanillaX
         if ($value=="true") {
             return true;
         }
@@ -166,7 +167,7 @@ final class GameRules {
             return false;
         }
 
-        return true;;
+        return true; //If theres no value for some reason/null avoids exception, Instead sets the gamerule to True
     }
 
     /**


### PR DESCRIPTION
Old Gamerule Reading Expects stringType tag only, added so it won't crash even if it reads bool/int type tag, as well as null or Gamerule without Value yet.

Some plugins Write to level.dat and saves it into different typeTag. Eg. VanillaX
