### PR TITLE
Add protocol version 471 for mc:be 1.17.40 (PM4)

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -6,7 +6,7 @@ version: 1.7.0-beta2
 main: czechpmdevs\multiworld\MultiWorld
 description: Plugin that manage with worlds
 website: https://github.com/CzechPMDevs/MultiWorld
-mcpe-protocol: [440, 448, 465]
+mcpe-protocol: [440, 448, 465, "471"]
 extensions:
   Core: '>=8.0'
 


### PR DESCRIPTION
Why do you don't delete the protocol-version value in the PM4 branch? xD