### PR TITLE
Fixed /mw help 3

### DIFF
--- a/src/czechpmdevs/multiworld/command/subcommand/HelpSubCommand.php
+++ b/src/czechpmdevs/multiworld/command/subcommand/HelpSubCommand.php
@@ -49,7 +49,9 @@ class HelpSubCommand implements SubCommand {
 
 		$message = LanguageManager::translateMessage($sender, "help", [(string)$page, "3"]);
 		for($i = $j = (($page - 1) * 5) + 1, $j = $j + 5; $i < $j; ++$i) {
-			$message .= "\n" . LanguageManager::translateMessage($sender, "help-$i");
+			if (1 <= $i && $i <= 12) {
+				$message .= "\n" . LanguageManager::translateMessage($sender, "help-$i");
+			}
 		}
 		return $message;
 	}


### PR DESCRIPTION
Fixed where referencing an out of range value would result in an error message
```bash
[13:11:42.532] [Server thread/ERROR]: [MultiWorld] LanguageManager error: Undefined array key "help-13" Try remove language resources and restart the server.
[13:11:42.532] [Server thread/ERROR]: [MultiWorld] LanguageManager error: Undefined array key "help-14" Try remove language resources and restart the server.
[13:11:42.532] [Server thread/ERROR]: [MultiWorld] LanguageManager error: Undefined array key "help-15" Try remove language resources and restart the server.
```